### PR TITLE
Baseline for unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ examples/db_team_bot/
 .env
 .idea
 .vscode/settings.json
+coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,8 @@ possible with your report. If you can, please include:
 * Create, or link to an existing issue identifying the need driving your PR request. The issue can contain more details of the need for the PR as well as host debate as to which course of action the PR will take that will most serve the common good.
 * Include screenshots and animated GIFs in your pull request whenever possible.
 * Follow the JavaScript coding style with details from `.jscsrc` and `.editorconfig` files and use necessary plugins for your text editor.
+* Run `npm test` before submitting and fix any issues.
+* Add tests to cover any new functionality. Add and/or update tests for any updates to the code.
 * Write documentation in [Markdown](https://daringfireball.net/projects/markdown).
 * Please follow, [JSDoc](http://usejsdoc.org/) for proper documentation.
 * Use short, present tense commit messages. See [Commit Message Styleguide](#git-commit-messages).

--- a/__test__/lib/Botkit.test.js
+++ b/__test__/lib/Botkit.test.js
@@ -1,16 +1,16 @@
 let botkit;
 
 beforeEach(() => {
-    jest.mock('../../lib/CoreBot', () => 'corebot')
-    jest.mock('../../lib/SlackBot', () => 'slackbot')
-    jest.mock('../../lib/Facebook', () => 'facebook')
-    jest.mock('../../lib/TwilioIPMBot', () => 'twilio')
-    jest.mock('../../lib/BotFramework', () => 'botframework')
-    jest.mock('../../lib/CiscoSparkbot', () => 'spark')
-    jest.mock('../../lib/ConsoleBot', () => 'console')
+    jest.mock('../../lib/CoreBot', () => 'corebot');
+    jest.mock('../../lib/SlackBot', () => 'slackbot');
+    jest.mock('../../lib/Facebook', () => 'facebook');
+    jest.mock('../../lib/TwilioIPMBot', () => 'twilio');
+    jest.mock('../../lib/BotFramework', () => 'botframework');
+    jest.mock('../../lib/CiscoSparkbot', () => 'spark');
+    jest.mock('../../lib/ConsoleBot', () => 'console');
 
     botkit = require('../../lib/Botkit');
-})
+});
 
 test('exports bot interfaces', () => {
     expect(botkit.core).toBe('corebot');

--- a/__test__/lib/Botkit.test.js
+++ b/__test__/lib/Botkit.test.js
@@ -1,0 +1,23 @@
+let botkit;
+
+beforeEach(() => {
+    jest.mock('../../lib/CoreBot', () => 'corebot')
+    jest.mock('../../lib/SlackBot', () => 'slackbot')
+    jest.mock('../../lib/Facebook', () => 'facebook')
+    jest.mock('../../lib/TwilioIPMBot', () => 'twilio')
+    jest.mock('../../lib/BotFramework', () => 'botframework')
+    jest.mock('../../lib/CiscoSparkbot', () => 'spark')
+    jest.mock('../../lib/ConsoleBot', () => 'console')
+
+    botkit = require('../../lib/Botkit');
+})
+
+test('exports bot interfaces', () => {
+    expect(botkit.core).toBe('corebot');
+    expect(botkit.slackbot).toBe('slackbot');
+    expect(botkit.facebookbot).toBe('facebook');
+    expect(botkit.twilioipmbot).toBe('twilio');
+    expect(botkit.botframeworkbot).toBe('botframework');
+    expect(botkit.sparkbot).toBe('spark');
+    expect(botkit.consolebot).toBe('console');
+});

--- a/__test__/lib/Botkit.test.js
+++ b/__test__/lib/Botkit.test.js
@@ -1,14 +1,15 @@
 let botkit;
 
-beforeEach(() => {
-    jest.mock('../../lib/CoreBot', () => 'corebot');
-    jest.mock('../../lib/SlackBot', () => 'slackbot');
-    jest.mock('../../lib/Facebook', () => 'facebook');
-    jest.mock('../../lib/TwilioIPMBot', () => 'twilio');
-    jest.mock('../../lib/BotFramework', () => 'botframework');
-    jest.mock('../../lib/CiscoSparkbot', () => 'spark');
-    jest.mock('../../lib/ConsoleBot', () => 'console');
+jest.mock('../../lib/CoreBot', () => 'corebot');
+jest.mock('../../lib/SlackBot', () => 'slackbot');
+jest.mock('../../lib/Facebook', () => 'facebook');
+jest.mock('../../lib/TwilioIPMBot', () => 'twilio');
+jest.mock('../../lib/BotFramework', () => 'botframework');
+jest.mock('../../lib/CiscoSparkbot', () => 'spark');
+jest.mock('../../lib/ConsoleBot', () => 'console');
 
+beforeEach(() => {
+    jest.clearAllMocks();
     botkit = require('../../lib/Botkit');
 });
 

--- a/__test__/lib/Slack_web_api.test.js
+++ b/__test__/lib/Slack_web_api.test.js
@@ -1,0 +1,36 @@
+let slackWebApi;
+let mockRequest;
+let mockBot;
+
+beforeEach(() => {
+
+    mockRequest = {
+        post: jest.fn()
+    };
+    jest.mock('request', () => mockRequest);
+
+    mockBot = {
+        config: {},
+        debug: jest.fn(),
+        log: jest.fn(),
+        userAgent: jest.fn()
+    };
+
+    mockBot.log.error = jest.fn();
+
+    slackWebApi = require('../../lib/Slack_web_api');
+});
+
+describe('config', function() {
+    test('default api_root', () => {
+        const instance = slackWebApi(mockBot, {});
+        expect(instance.api_url).toBe('https://slack.com/api/');
+    });
+
+    test('setting api_root', () => {
+        mockBot.config.api_root = 'http://www.somethingelse.com';
+        const instance = slackWebApi(mockBot, {});
+        expect(instance.api_url).toBe('http://www.somethingelse.com/api/');
+    });
+});
+

--- a/__test__/lib/Slack_web_api.test.js
+++ b/__test__/lib/Slack_web_api.test.js
@@ -1,13 +1,24 @@
 let slackWebApi;
 let mockRequest;
+let mockResponse;
+let responseError;
 let mockBot;
+mockRequest = {
+    post: jest.fn()
+};
+
+jest.mock('request', () => mockRequest);
+
 
 beforeEach(() => {
+    jest.clearAllMocks();
 
-    mockRequest = {
-        post: jest.fn()
-    };
-    jest.mock('request', () => mockRequest);
+    responseError = null;
+
+    mockResponse = {
+        statusCode: 200,
+        body: '{}'
+    }
 
     mockBot = {
         config: {},
@@ -18,10 +29,14 @@ beforeEach(() => {
 
     mockBot.log.error = jest.fn();
 
+    mockRequest.post.mockImplementation((params, cb) => {
+        cb(null, mockResponse, mockResponse.body);
+    });
+
     slackWebApi = require('../../lib/Slack_web_api');
 });
 
-describe('config', function() {
+describe('config', () => {
     test('default api_root', () => {
         const instance = slackWebApi(mockBot, {});
         expect(instance.api_url).toBe('https://slack.com/api/');
@@ -34,3 +49,145 @@ describe('config', function() {
     });
 });
 
+describe('callApi', () => {
+    let instance;
+
+    test('uses data.token by default and post', () => {
+        const data = {
+            token: 'abc123'
+        };
+        const cb = jest.fn();
+
+        instance = slackWebApi(mockBot, {});
+        instance.callAPI('some.method', data, cb);
+
+        expect(mockRequest.post.mock.calls.length).toBe(1);
+        const firstArg = mockRequest.post.mock.calls[0][0];
+        expect(firstArg.form.token).toBe('abc123');
+    });
+
+    test('uses config.token if data.token is missing', () => {
+        const data = {};
+        const cb = jest.fn();
+
+        instance = slackWebApi(mockBot, { token: 'abc123' });
+        instance.callAPI('some.method', data, cb);
+
+        expect(mockRequest.post.mock.calls.length).toBe(1);
+        const firstArg = mockRequest.post.mock.calls[0][0];
+        expect(firstArg.form.token).toBe('abc123');
+    });
+});
+
+describe('callApiWithoutToken', () => {
+    let instance;
+
+    test('uses data values by default', () => {
+        const data = {
+            client_id: 'id',
+            client_secret: 'secret',
+            redirect_uri: 'redirectUri'
+        };
+        const cb = jest.fn();
+
+        instance = slackWebApi(mockBot, {});
+        instance.callAPIWithoutToken('some.method', data, cb);
+
+        expect(mockRequest.post.mock.calls.length).toBe(1);
+        const firstArg = mockRequest.post.mock.calls[0][0];
+        expect(firstArg.form.client_id).toBe('id');
+        expect(firstArg.form.client_secret).toBe('secret');
+        expect(firstArg.form.redirect_uri).toBe('redirectUri');
+    });
+
+    test('uses config values if not set in data', () => {
+        const config = {
+            clientId: 'id',
+            clientSecret: 'secret',
+            redirectUri: 'redirectUri'
+        };
+        const cb = jest.fn();
+
+        // this seems to be an API inconsistency:
+        // callAPIWithoutToken uses bot.config, but callAPI uses that passed config
+        mockBot.config = config;
+
+        instance = slackWebApi(mockBot, {});
+        instance.callAPIWithoutToken('some.method', {}, cb);
+
+        expect(mockRequest.post.mock.calls.length).toBe(1);
+        const firstArg = mockRequest.post.mock.calls[0][0];
+        expect(firstArg.form.client_id).toBe('id');
+        expect(firstArg.form.client_secret).toBe('secret');
+        expect(firstArg.form.redirect_uri).toBe('redirectUri');
+
+    });
+});
+
+describe('postForm', () => {
+
+    test('handles success', () => {
+
+    });
+
+    test('handles multipart data', () => {
+
+    });
+
+    test('handles request lib error', () => {
+
+    });
+
+    test('handles non 200 response code', () => {
+
+    });
+
+    test('handles error parsing body', () => {
+
+    });
+
+    test('handles ok.false response', () => {
+
+    });
+});
+
+
+describe('api methods', () => {
+    let instance;
+
+    beforeEach(() => {
+        instance = slackWebApi(mockBot, {});
+    });
+
+    test('spot check api methods ', () => {
+        // testing for all methods seems wasteful, but let's confirm the methods got built correctly and test the following scenarios
+
+        // two levels
+        expect(instance.auth).toBeDefined();
+        expect(instance.auth.test).toBeDefined();
+
+        // three levels
+        expect(instance.users).toBeDefined();
+        expect(instance.users.profile).toBeDefined();
+        expect(instance.users.profile.get).toBeDefined();
+    });
+
+    describe('special cases', () => {
+
+        beforeEach(() => {
+
+        });
+
+        test('chat.postMessage ', () => {
+
+        });
+
+        test('chat.update ', () => {
+
+        });
+
+        test('files.upload ', () => {
+
+        });
+    });
+});

--- a/__test__/lib/Slack_web_api.test.js
+++ b/__test__/lib/Slack_web_api.test.js
@@ -1,20 +1,13 @@
 let slackWebApi;
 let mockRequest;
 let mockResponse;
-let responseError;
 let mockBot;
 
-mockRequest = {
-    post: jest.fn()
-};
+mockRequest = {};
 
 jest.mock('request', () => mockRequest);
 
 beforeEach(() => {
-    jest.clearAllMocks();
-
-    responseError = null;
-
     mockResponse = {
         statusCode: 200,
         body: '{"ok": true}'
@@ -29,7 +22,7 @@ beforeEach(() => {
 
     mockBot.log.error = jest.fn();
 
-    mockRequest.post.mockImplementation((params, cb) => {
+    mockRequest.post = jest.fn().mockImplementation((params, cb) => {
         cb(null, mockResponse, mockResponse.body);
     });
 
@@ -61,7 +54,7 @@ describe('callApi', () => {
         instance = slackWebApi(mockBot, {});
         instance.callAPI('some.method', data, cb);
 
-        expect(mockRequest.post.mock.calls.length).toBe(1);
+        expect(mockRequest.post).toHaveBeenCalledTimes(1);
         const firstArg = mockRequest.post.mock.calls[0][0];
         expect(firstArg.form.token).toBe('abc123');
     });
@@ -73,7 +66,7 @@ describe('callApi', () => {
         instance = slackWebApi(mockBot, { token: 'abc123' });
         instance.callAPI('some.method', data, cb);
 
-        expect(mockRequest.post.mock.calls.length).toBe(1);
+        expect(mockRequest.post).toHaveBeenCalledTimes(1);
         const firstArg = mockRequest.post.mock.calls[0][0];
         expect(firstArg.form.token).toBe('abc123');
     });
@@ -163,7 +156,7 @@ describe('postForm', () => {
         });
 
         test(`${methodName}: defaults callback`, () => {
-            method('some.action', 'data', null);
+            method('some.action', 'data');
             expect(mockRequest.post).toHaveBeenCalledTimes(1);
         });
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -156,7 +156,7 @@ module.exports = function(botkit, config) {
             }
 
             bot.rtm = new Ws(res.url, null, {
-              agent: agent
+                agent: agent
             });
             bot.msgcount = 1;
 

--- a/package.json
+++ b/package.json
@@ -36,9 +36,8 @@
   },
   "scripts": {
     "pretest": "jscs ./lib/ ./__test__",
-    "test": "mocha tests/*.js",
-    "jest": "jest",
-    "jest-watch": "jest --watch"
+    "test": "jest",
+    "test-legacy": "mocha ./tests/*.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
   },
   "scripts": {
     "pretest": "jscs ./lib/ ./__test__ --fix",
-    "test": "jest",
-    "test-legacy": "mocha ./tests/*.js"
+    "test": "jest --coverage",
+    "test-legacy": "mocha ./tests/*.js",
+    "test-watch": "jest --watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ws": "^2.2.2"
   },
   "devDependencies": {
+    "jest-cli": "^20.0.1",
     "jscs": "^3.0.7",
     "mocha": "^3.2.0",
     "should": "^11.2.1",
@@ -34,8 +35,10 @@
     "winston": "^2.3.1"
   },
   "scripts": {
-    "pretest": "jscs ./lib/",
-    "test": "mocha tests/*.js"
+    "pretest": "jscs ./lib/ ./__test__",
+    "test": "mocha tests/*.js",
+    "jest": "jest",
+    "jest-watch": "jest --watch"
   },
   "repository": {
     "type": "git",
@@ -55,5 +58,8 @@
     "microsoft bot framework"
   ],
   "author": "ben@howdy.ai",
-  "license": "MIT"
+  "license": "MIT",
+  "jest": {
+    "testEnvironment": "node"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "winston": "^2.3.1"
   },
   "scripts": {
-    "pretest": "jscs ./lib/ ./__test__",
+    "pretest": "jscs ./lib/ ./__test__ --fix",
     "test": "jest",
     "test-legacy": "mocha ./tests/*.js"
   },

--- a/readme.md
+++ b/readme.md
@@ -148,11 +148,17 @@ To run tests, use the npm `test` command. Note: you will need dev dependencies i
 npm test
 ```
 
-Tests are run with [Jest](https://facebook.github.io/jest/docs/getting-started.html). You can pass Jest command line options after a `--`.
-For example to have Jest watch for file changes you can run
+To run tests in watch mode run:
 
 ```bash
-npm test -- --watch
+npm run test-watch
+```
+
+Tests are run with [Jest](https://facebook.github.io/jest/docs/getting-started.html). You can pass Jest command line options after a `--`.
+For example to have Jest bail on the first error you can run
+
+```bash
+npm test -- --bail
 ```
 
 ## Documentation

--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,21 @@ Use the `--production` flag to skip the installation of devDependencies from Bot
 npm install --production
 ```
 
+## Running Tests
+
+To run tests, use the npm `test` command. Note: you will need dev dependencies installed using `npm install`.
+
+```bash
+npm test
+```
+
+Tests are run with [Jest](https://facebook.github.io/jest/docs/getting-started.html). You can pass Jest command line options after a `--`.
+For example to have Jest watch for file changes you can run
+
+```bash
+npm test -- --watch
+```
+
 ## Documentation
 
 * [Get Started](docs/readme.md)


### PR DESCRIPTION
My goal is to write true unit tests that isolate components from each other. For this PR I hit 100% coverage on all statements/branches/functions/lines for the files I wrote tests for (run `npm test` to see the coverage report). 

For now I just covered the main `botkit.js` entry point and `slack_web_api.js` since they were relatively small and I know them well. If this PR looks good, I can start adding more tests, file by file.

I chose Jest because of the great CLI and it's speed. It also reduces the number of additional tools to know before writing tests.

I updated/added some npm scripts:
* To run linting and tests: `npm test`
* To run tests in watch mode: `npm run test-watch`
* To run existing mocha/should integration tests (these will be deprecated once tests are backfilled): `npm run test-legacy`

NOTE: Linting now runs with `--fix` to fix common mistakes.